### PR TITLE
docs: fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ```shell
 echo vpn.server.name >server_name.txt
-echo resolvectl query $(cat server_name.txt) --json=short --type=A | \
-  jq -r '.address | join(".")' >server_addr.txt
+host $(cat server_name.txt) | grep "has address" | \
+  awk '{print $NF}' >server_ip.txt
 echo username >username.txt
 echo password >password.txt
 ```


### PR DESCRIPTION
Hi.

`resolvectl` command written in the README.txt does not work on my environment because:
-  `resolvectl` does not have `--json` parameter on my environment (Pop! OS 22.04)
- According to compose.yaml, `server_ip.txt` is actually required one not `server_addr.txt`.